### PR TITLE
Use of usings and transactions

### DIFF
--- a/SourceFormats/SourceFormatsRepository.Int.Tests/BaseTest.cs
+++ b/SourceFormats/SourceFormatsRepository.Int.Tests/BaseTest.cs
@@ -29,8 +29,9 @@ public class BaseTest
             .Options;
         SourceFormatsDbContext ctx = new SourceFormatsDbContext(sourceFormatNodeDbContextOptions);
         ctx.Database.EnsureCreated();
+
         ISourceFormatNodeRepository sourceFormatNodeRepository = new SourceFormatNodeRepository(
-            ctx,
+            sourceFormatNodeDbContextOptions,
             new SourceFormatNodeValidator(),
             new GuardsService());
         Sut = new SourceFormatsRepository(sourceFormatNodeRepository);

--- a/SourceFormats/SourceFormatsRepository.Int.Tests/SourceFormatNode/AddChildNodeShould.cs
+++ b/SourceFormats/SourceFormatsRepository.Int.Tests/SourceFormatNode/AddChildNodeShould.cs
@@ -89,7 +89,6 @@ public class AddChildNodeShould : BaseTest
         // Assert
         await action.Should()
             .ThrowExactlyAsync<SourceFormatNodeRepositoryException>()
-            .WithInnerExceptionExactly<SourceFormatNodeRepositoryException, SourceFormatNodeRepositoryException>()
             .ConfigureAwait(false);
     }
 }

--- a/SourceFormats/SourceFormatsRepository.Int.Tests/SourceFormatNode/AddChildNodeValidationShould.cs
+++ b/SourceFormats/SourceFormatsRepository.Int.Tests/SourceFormatNode/AddChildNodeValidationShould.cs
@@ -3,7 +3,6 @@ namespace EncyclopediaGalactica.SourceFormats.SourceFormatsRepository.Int.Tests.
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using Exceptions;
 using FluentAssertions;
 using Utils.GuardsService;
 using Xunit;
@@ -27,9 +26,7 @@ public class AddChildNodeValidationShould : BaseTest
 
         // Assert
         await action.Should()
-            .ThrowExactlyAsync<SourceFormatNodeRepositoryException>()
-            .WithInnerExceptionExactly<SourceFormatNodeRepositoryException, GuardsServiceException>()
-            .WithInnerExceptionExactly<GuardsServiceException, GuardsServiceValueShouldNotBeEqualToException>()
+            .ThrowExactlyAsync<GuardsServiceException>()
             .ConfigureAwait(false);
     }
 }

--- a/SourceFormats/SourceFormatsRepository.Int.Tests/SourceFormatNode/DeleteShould.cs
+++ b/SourceFormats/SourceFormatsRepository.Int.Tests/SourceFormatNode/DeleteShould.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Entities;
-using Exceptions;
 using FluentAssertions;
 using Xunit;
 
@@ -17,8 +16,7 @@ public class DeleteShould : BaseTest
     public async Task DeleteItem()
     {
         // Arrange
-        SourceFormatNode node =
-            await Sut.SourceFormatNodes.AddAsync(new SourceFormatNode("asd")).ConfigureAwait(false);
+        SourceFormatNode node = await Sut.SourceFormatNodes.AddAsync(new SourceFormatNode("asd")).ConfigureAwait(false);
 
         // Act
         await Sut.SourceFormatNodes.DeleteAsync(node.Id).ConfigureAwait(false);
@@ -145,8 +143,7 @@ public class DeleteShould : BaseTest
 
         // Assert
         await action.Should()
-            .ThrowExactlyAsync<SourceFormatNodeRepositoryException>()
-            .WithInnerExceptionExactly<SourceFormatNodeRepositoryException, SourceFormatNodeRepositoryException>()
+            .ThrowExactlyAsync<InvalidOperationException>()
             .ConfigureAwait(false);
     }
 }

--- a/SourceFormats/SourceFormatsRepository.Int.Tests/SourceFormatNode/DeleteValidationShould.cs
+++ b/SourceFormats/SourceFormatsRepository.Int.Tests/SourceFormatNode/DeleteValidationShould.cs
@@ -3,7 +3,6 @@ namespace EncyclopediaGalactica.SourceFormats.SourceFormatsRepository.Int.Tests.
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using Exceptions;
 using FluentAssertions;
 using Utils.GuardsService;
 using Xunit;
@@ -22,9 +21,7 @@ public class DeleteValidationShould : BaseTest
 
         // Assert
         await action.Should()
-            .ThrowExactlyAsync<SourceFormatNodeRepositoryException>()
-            .WithInnerExceptionExactly<SourceFormatNodeRepositoryException, GuardsServiceException>()
-            .WithInnerExceptionExactly<GuardsServiceException, GuardsServiceValueShouldNotBeEqualToException>()
+            .ThrowExactlyAsync<GuardsServiceException>()
             .ConfigureAwait(false);
     }
 }

--- a/SourceFormats/SourceFormatsRepository.Int.Tests/SourceFormatNode/GetByIdValidationShould.cs
+++ b/SourceFormats/SourceFormatsRepository.Int.Tests/SourceFormatNode/GetByIdValidationShould.cs
@@ -20,9 +20,7 @@ public class GetByIdValidationShould : BaseTest
 
         // Assert
         await action.Should()
-            .ThrowExactlyAsync<SourceFormatNodeRepositoryException>()
-            .WithInnerExceptionExactly<SourceFormatNodeRepositoryException, GuardsServiceException>()
-            .WithInnerExceptionExactly<GuardsServiceException, GuardsServiceValueShouldNotBeEqualToException>()
+            .ThrowExactlyAsync<GuardsServiceException>()
             .ConfigureAwait(false);
     }
 
@@ -35,7 +33,6 @@ public class GetByIdValidationShould : BaseTest
         // Assert
         await action.Should()
             .ThrowExactlyAsync<SourceFormatNodeRepositoryException>()
-            .WithInnerExceptionExactly<SourceFormatNodeRepositoryException, SourceFormatNodeRepositoryException>()
             .ConfigureAwait(false);
     }
 }

--- a/SourceFormats/SourceFormatsRepository.Int.Tests/SourceFormatNode/GetByIdWithChildrenValidationShould.cs
+++ b/SourceFormats/SourceFormatsRepository.Int.Tests/SourceFormatNode/GetByIdWithChildrenValidationShould.cs
@@ -3,7 +3,6 @@ namespace EncyclopediaGalactica.SourceFormats.SourceFormatsRepository.Int.Tests.
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using Exceptions;
 using FluentAssertions;
 using Utils.GuardsService;
 using Xunit;
@@ -23,9 +22,7 @@ public class GetByIdWithChildrenValidationShould : BaseTest
 
         // Assert
         await action.Should()
-            .ThrowExactlyAsync<SourceFormatNodeRepositoryException>()
-            .WithInnerExceptionExactly<SourceFormatNodeRepositoryException, GuardsServiceException>()
-            .WithInnerExceptionExactly<GuardsServiceException, GuardsServiceValueShouldNotBeEqualToException>()
+            .ThrowExactlyAsync<GuardsServiceException>()
             .ConfigureAwait(false);
     }
 }

--- a/SourceFormats/SourceFormatsRepository.Int.Tests/SourceFormatNode/GetByIdWithTreeValidationShould.cs
+++ b/SourceFormats/SourceFormatsRepository.Int.Tests/SourceFormatNode/GetByIdWithTreeValidationShould.cs
@@ -3,7 +3,6 @@ namespace EncyclopediaGalactica.SourceFormats.SourceFormatsRepository.Int.Tests.
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
-using Exceptions;
 using FluentAssertions;
 using Utils.GuardsService;
 using Xunit;
@@ -23,9 +22,7 @@ public class GetByIdWithTreeValidationShould : BaseTest
 
         // Assert
         await action.Should()
-            .ThrowExactlyAsync<SourceFormatNodeRepositoryException>()
-            .WithInnerExceptionExactly<SourceFormatNodeRepositoryException, GuardsServiceException>()
-            .WithInnerExceptionExactly<GuardsServiceException, GuardsServiceValueShouldNotBeEqualToException>()
+            .ThrowExactlyAsync<GuardsServiceException>()
             .ConfigureAwait(false);
     }
 }

--- a/SourceFormats/SourceFormatsRepository.Int.Tests/SourceFormatNode/UpdateShould.cs
+++ b/SourceFormats/SourceFormatsRepository.Int.Tests/SourceFormatNode/UpdateShould.cs
@@ -4,7 +4,6 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Entities;
-using Exceptions;
 using FluentAssertions;
 using Xunit;
 
@@ -46,8 +45,7 @@ public class UpdateShould : BaseTest
 
         // Assert
         await action.Should()
-            .ThrowExactlyAsync<SourceFormatNodeRepositoryException>()
-            .WithInnerExceptionExactly<SourceFormatNodeRepositoryException, InvalidOperationException>()
+            .ThrowExactlyAsync<InvalidOperationException>()
             .ConfigureAwait(false);
     }
 }

--- a/SourceFormats/SourceFormatsRepository.Unit.Tests/SourceFormatNode/SourceFormatNodeShould.cs
+++ b/SourceFormats/SourceFormatsRepository.Unit.Tests/SourceFormatNode/SourceFormatNodeShould.cs
@@ -37,8 +37,7 @@ public class SourceFormatNodeShould
     {
         DbContextOptions<SourceFormatsDbContext> options = new DbContextOptionsBuilder<SourceFormatsDbContext>()
             .Options;
-        SourceFormatsDbContext ctx = new SourceFormatsDbContext(options);
-        Action action = () => { new SourceFormatNodeRepository(ctx, null!, new GuardsService()); };
+        Action action = () => { new SourceFormatNodeRepository(options, null!, new GuardsService()); };
 
         action.Should().ThrowExactly<ArgumentNullException>();
     }
@@ -48,8 +47,7 @@ public class SourceFormatNodeShould
     {
         DbContextOptions<SourceFormatsDbContext> options = new DbContextOptionsBuilder<SourceFormatsDbContext>()
             .Options;
-        SourceFormatsDbContext ctx = new SourceFormatsDbContext(options);
-        Action action = () => { new SourceFormatNodeRepository(ctx, new SourceFormatNodeValidator(), null!); };
+        Action action = () => { new SourceFormatNodeRepository(options, new SourceFormatNodeValidator(), null!); };
 
         action.Should().ThrowExactly<ArgumentNullException>();
     }

--- a/SourceFormats/SourceFormatsRepository/SourceFormatNode/Delete.cs
+++ b/SourceFormats/SourceFormatsRepository/SourceFormatNode/Delete.cs
@@ -1,34 +1,43 @@
 namespace EncyclopediaGalactica.SourceFormats.SourceFormatsRepository.SourceFormatNode;
 
+using Ctx;
 using Entities;
 using Exceptions;
+using Microsoft.EntityFrameworkCore.Storage;
 
 public partial class SourceFormatNodeRepository
 {
     /// <inheritdoc />
     public async Task DeleteAsync(long id, CancellationToken cancellationToken = default)
     {
-        try
+        await using SourceFormatsDbContext ctx = new SourceFormatsDbContext(_dbContextOptions);
+        await using (IDbContextTransaction transaction = await ctx.Database
+                         .BeginTransactionAsync(cancellationToken).ConfigureAwait(false))
         {
-            _guards.NotNull(id);
-            _guards.IsNotEqual(id, 0);
-
-            List<SourceFormatNode> toBeDelete = await GetByIdWithFlatTreeAsync(id, cancellationToken)
-                .ConfigureAwait(false);
-
-            if (toBeDelete.Any())
+            try
             {
-                _ctx.SourceFormatNodes.RemoveRange(toBeDelete);
-                await _ctx.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-                return;
-            }
+                _guards.NotNull(id);
+                _guards.IsNotEqual(id, 0);
 
-            throw new SourceFormatNodeRepositoryException($"No {nameof(SourceFormatNode)} entity with id:{id}.");
-        }
-        catch (Exception e)
-        {
-            string msg = prepErrorMessage(nameof(DeleteAsync));
-            throw new SourceFormatNodeRepositoryException(msg, e);
+                List<SourceFormatNode> toBeDelete = await GetByIdWithFlatTreeAsync(id, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (toBeDelete.Any())
+                {
+                    ctx.SourceFormatNodes.RemoveRange(toBeDelete);
+                    await ctx.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                    await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                    return;
+                }
+
+                throw new SourceFormatNodeRepositoryException(
+                    $"No {nameof(SourceFormatNode)} entity with id:{id}.");
+            }
+            catch (Exception e)
+            {
+                // logging comes here
+                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/SourceFormats/SourceFormatsRepository/SourceFormatNode/Delete.cs
+++ b/SourceFormats/SourceFormatsRepository/SourceFormatNode/Delete.cs
@@ -11,15 +11,15 @@ public partial class SourceFormatNodeRepository
     public async Task DeleteAsync(long id, CancellationToken cancellationToken = default)
     {
         await using SourceFormatsDbContext ctx = new SourceFormatsDbContext(_dbContextOptions);
-        await using (IDbContextTransaction transaction = await ctx.Database
-                         .BeginTransactionAsync(cancellationToken).ConfigureAwait(false))
+        await using (IDbContextTransaction transaction = await ctx.Database.BeginTransactionAsync
+                         (cancellationToken).ConfigureAwait(false))
         {
             try
             {
                 _guards.NotNull(id);
                 _guards.IsNotEqual(id, 0);
 
-                List<SourceFormatNode> toBeDelete = await GetByIdWithFlatTreeAsync(id, cancellationToken)
+                List<SourceFormatNode> toBeDelete = await GetByIdWithFlatTreeAsync(id, ctx, cancellationToken)
                     .ConfigureAwait(false);
 
                 if (toBeDelete.Any())
@@ -37,6 +37,7 @@ public partial class SourceFormatNodeRepository
             {
                 // logging comes here
                 await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                throw;
             }
         }
     }

--- a/SourceFormats/SourceFormatsRepository/SourceFormatNode/GetAll.cs
+++ b/SourceFormats/SourceFormatsRepository/SourceFormatNode/GetAll.cs
@@ -1,7 +1,7 @@
 namespace EncyclopediaGalactica.SourceFormats.SourceFormatsRepository.SourceFormatNode;
 
+using Ctx;
 using Entities;
-using Exceptions;
 using Microsoft.EntityFrameworkCore;
 
 public partial class SourceFormatNodeRepository
@@ -9,14 +9,15 @@ public partial class SourceFormatNodeRepository
     /// <inheritdoc />
     public async Task<List<SourceFormatNode>> GetAllAsync(CancellationToken cancellationToken = default)
     {
+        await using SourceFormatsDbContext ctx = new SourceFormatsDbContext(_dbContextOptions);
         try
         {
-            return await _ctx.SourceFormatNodes.ToListAsync(cancellationToken).ConfigureAwait(false);
+            return await ctx.SourceFormatNodes.ToListAsync(cancellationToken).ConfigureAwait(false);
         }
         catch (Exception e)
         {
-            string msg = prepErrorMessage(nameof(GetAllAsync));
-            throw new SourceFormatNodeRepositoryException(msg, e);
+            // logging comes here
+            throw;
         }
     }
 }

--- a/SourceFormats/SourceFormatsRepository/SourceFormatNode/GetById.cs
+++ b/SourceFormats/SourceFormatsRepository/SourceFormatNode/GetById.cs
@@ -1,5 +1,6 @@
 namespace EncyclopediaGalactica.SourceFormats.SourceFormatsRepository.SourceFormatNode;
 
+using Ctx;
 using Entities;
 using Exceptions;
 
@@ -8,11 +9,12 @@ public partial class SourceFormatNodeRepository
     /// <inheritdoc />
     public async Task<SourceFormatNode> GetByIdAsync(long id)
     {
+        await using SourceFormatsDbContext ctx = new SourceFormatsDbContext(_dbContextOptions);
         try
         {
             _guards.IsNotEqual(id, 0);
 
-            SourceFormatNode? result = await _ctx.SourceFormatNodes.FindAsync(id).ConfigureAwait(false);
+            SourceFormatNode? result = await ctx.SourceFormatNodes.FindAsync(id).ConfigureAwait(false);
 
             if (result is null)
                 throw new SourceFormatNodeRepositoryException(
@@ -22,8 +24,8 @@ public partial class SourceFormatNodeRepository
         }
         catch (Exception e)
         {
-            string msg = prepErrorMessage(nameof(GetByIdAsync));
-            throw new SourceFormatNodeRepositoryException(msg, e);
+            // logging comes here
+            throw;
         }
     }
 }

--- a/SourceFormats/SourceFormatsRepository/SourceFormatNode/GetByIdWithChildren.cs
+++ b/SourceFormats/SourceFormatsRepository/SourceFormatNode/GetByIdWithChildren.cs
@@ -1,7 +1,7 @@
 namespace EncyclopediaGalactica.SourceFormats.SourceFormatsRepository.SourceFormatNode;
 
+using Ctx;
 using Entities;
-using Exceptions;
 using Microsoft.EntityFrameworkCore;
 
 public partial class SourceFormatNodeRepository
@@ -9,11 +9,12 @@ public partial class SourceFormatNodeRepository
     /// <inheritdoc />
     public async Task<SourceFormatNode> GetByIdWithChildrenAsync(long id, CancellationToken cancellationToken = default)
     {
+        await using SourceFormatsDbContext ctx = new SourceFormatsDbContext(_dbContextOptions);
         try
         {
             _guards.IsNotEqual(id, 0);
 
-            SourceFormatNode result = await _ctx.SourceFormatNodes
+            SourceFormatNode result = await ctx.SourceFormatNodes
                 .Include(i => i.ChildrenSourceFormatNodes)
                 .FirstAsync(w => w.Id == id, cancellationToken)
                 .ConfigureAwait(false);
@@ -21,8 +22,8 @@ public partial class SourceFormatNodeRepository
         }
         catch (Exception e)
         {
-            string msg = prepErrorMessage(nameof(GetByIdWithChildrenAsync));
-            throw new SourceFormatNodeRepositoryException(msg, e);
+            // logging comes here
+            throw;
         }
     }
 }

--- a/SourceFormats/SourceFormatsRepository/SourceFormatNode/GetByIdwithTreeAsync.cs
+++ b/SourceFormats/SourceFormatsRepository/SourceFormatNode/GetByIdwithTreeAsync.cs
@@ -9,36 +9,20 @@ using Microsoft.EntityFrameworkCore.Storage;
 public partial class SourceFormatNodeRepository
 {
     /// <inheritdoc />
-    public async Task<List<SourceFormatNode>> GetByIdWithFlatTreeAsync(
-        long id,
+    public async Task<List<SourceFormatNode>> GetByIdWithFlatTreeAsync(long id,
         CancellationToken cancellationToken = default)
     {
         await using SourceFormatsDbContext ctx = new SourceFormatsDbContext(_dbContextOptions);
-        await using (IDbContextTransaction transaction = await ctx.Database
-                         .BeginTransactionAsync(cancellationToken).ConfigureAwait(false))
+        await using IDbContextTransaction transaction = await ctx.Database.BeginTransactionAsync(cancellationToken)
+            .ConfigureAwait(false);
         {
             try
             {
                 _guards.IsNotEqual(id, 0);
-                ctx.ChangeTracker.Clear();
-                SourceFormatNode? startNodeInTree = await ctx.SourceFormatNodes
-                    .FirstAsync(p => p.Id == id, cancellationToken)
+                List<SourceFormatNode> nodeList = await GetByIdWithFlatTreeAsync(id, ctx, cancellationToken)
                     .ConfigureAwait(false);
-                if (startNodeInTree is null)
-                    throw new SourceFormatNodeRepositoryException(
-                        $"No {nameof(SourceFormatNode)} entity in the system with id: {id}");
-                if (startNodeInTree.ChildrenSourceFormatNodes.Any())
-                    throw new SourceFormatNodeRepositoryException(
-                        $"Entity with id: {id} should not include its children.");
-
-                List<SourceFormatNode> sourceFormatNodes = await ctx.SourceFormatNodes
-                    .Where(w => w.RootNodeId == startNodeInTree.RootNodeId)
-                    .ToListAsync(cancellationToken)
-                    .ConfigureAwait(false);
-
-                List<SourceFormatNode> result = GetFlatTree(startNodeInTree, sourceFormatNodes);
                 await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-                return result;
+                return nodeList;
             }
             catch (Exception e)
             {
@@ -47,6 +31,32 @@ public partial class SourceFormatNodeRepository
                 throw;
             }
         }
+    }
+
+    private async Task<List<SourceFormatNode>> GetByIdWithFlatTreeAsync(
+        long id,
+        SourceFormatsDbContext ctx,
+        CancellationToken cancellationToken = default)
+    {
+        _guards.IsNotEqual(id, 0);
+        ctx.ChangeTracker.Clear();
+        SourceFormatNode? startNodeInTree = await ctx.SourceFormatNodes
+            .FirstAsync(p => p.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+        if (startNodeInTree is null)
+            throw new SourceFormatNodeRepositoryException(
+                $"No {nameof(SourceFormatNode)} entity in the system with id: {id}");
+        if (startNodeInTree.ChildrenSourceFormatNodes.Any())
+            throw new SourceFormatNodeRepositoryException(
+                $"Entity with id: {id} should not include its children.");
+
+        List<SourceFormatNode> sourceFormatNodes = await ctx.SourceFormatNodes
+            .Where(w => w.RootNodeId == startNodeInTree.RootNodeId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        List<SourceFormatNode> result = GetFlatTree(startNodeInTree, sourceFormatNodes);
+        return result;
     }
 
     private List<SourceFormatNode> GetFlatTree(SourceFormatNode node, List<SourceFormatNode> sourceFormatNodes)

--- a/SourceFormats/SourceFormatsRepository/SourceFormatNode/GetByIdwithTreeAsync.cs
+++ b/SourceFormats/SourceFormatsRepository/SourceFormatNode/GetByIdwithTreeAsync.cs
@@ -1,8 +1,10 @@
 namespace EncyclopediaGalactica.SourceFormats.SourceFormatsRepository.SourceFormatNode;
 
+using Ctx;
 using Entities;
 using Exceptions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 
 public partial class SourceFormatNodeRepository
 {
@@ -11,32 +13,39 @@ public partial class SourceFormatNodeRepository
         long id,
         CancellationToken cancellationToken = default)
     {
-        try
+        await using SourceFormatsDbContext ctx = new SourceFormatsDbContext(_dbContextOptions);
+        await using (IDbContextTransaction transaction = await ctx.Database
+                         .BeginTransactionAsync(cancellationToken).ConfigureAwait(false))
         {
-            _guards.IsNotEqual(id, 0);
-            _ctx.ChangeTracker.Clear();
-            SourceFormatNode? startNodeInTree = await _ctx.SourceFormatNodes
-                .FirstAsync(p => p.Id == id, cancellationToken)
-                .ConfigureAwait(false);
-            if (startNodeInTree is null)
-                throw new SourceFormatNodeRepositoryException(
-                    $"No {nameof(SourceFormatNode)} entity in the system with id: {id}");
-            if (startNodeInTree.ChildrenSourceFormatNodes.Any())
-                throw new SourceFormatNodeRepositoryException(
-                    $"Entity with id: {id} should not include its children.");
+            try
+            {
+                _guards.IsNotEqual(id, 0);
+                ctx.ChangeTracker.Clear();
+                SourceFormatNode? startNodeInTree = await ctx.SourceFormatNodes
+                    .FirstAsync(p => p.Id == id, cancellationToken)
+                    .ConfigureAwait(false);
+                if (startNodeInTree is null)
+                    throw new SourceFormatNodeRepositoryException(
+                        $"No {nameof(SourceFormatNode)} entity in the system with id: {id}");
+                if (startNodeInTree.ChildrenSourceFormatNodes.Any())
+                    throw new SourceFormatNodeRepositoryException(
+                        $"Entity with id: {id} should not include its children.");
 
-            List<SourceFormatNode> sourceFormatNodes = await _ctx.SourceFormatNodes
-                .Where(w => w.RootNodeId == startNodeInTree.RootNodeId)
-                .ToListAsync(cancellationToken)
-                .ConfigureAwait(false);
+                List<SourceFormatNode> sourceFormatNodes = await ctx.SourceFormatNodes
+                    .Where(w => w.RootNodeId == startNodeInTree.RootNodeId)
+                    .ToListAsync(cancellationToken)
+                    .ConfigureAwait(false);
 
-            List<SourceFormatNode> result = GetFlatTree(startNodeInTree, sourceFormatNodes);
-            return result;
-        }
-        catch (Exception e)
-        {
-            string msg = prepErrorMessage(nameof(GetByIdWithFlatTreeAsync));
-            throw new SourceFormatNodeRepositoryException(msg, e);
+                List<SourceFormatNode> result = GetFlatTree(startNodeInTree, sourceFormatNodes);
+                await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                return result;
+            }
+            catch (Exception e)
+            {
+                // logging comes here
+                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                throw;
+            }
         }
     }
 

--- a/SourceFormats/SourceFormatsRepository/SourceFormatNode/SourceFormatNodeRepository.cs
+++ b/SourceFormats/SourceFormatsRepository/SourceFormatNode/SourceFormatNodeRepository.cs
@@ -4,20 +4,21 @@ using Ctx;
 using Entities;
 using FluentValidation;
 using Interfaces;
+using Microsoft.EntityFrameworkCore;
 using Utils.GuardsService;
 
 public partial class SourceFormatNodeRepository : ISourceFormatNodeRepository
 {
-    private readonly SourceFormatsDbContext _ctx;
+    private readonly DbContextOptions<SourceFormatsDbContext> _dbContextOptions;
     private readonly IGuardsService _guards;
     private readonly IValidator<SourceFormatNode> _sourceFormatNodeValidator;
 
     public SourceFormatNodeRepository(
-        SourceFormatsDbContext ctx,
+        DbContextOptions<SourceFormatsDbContext> dbContextOptions,
         IValidator<SourceFormatNode> sourceFormatNodeValidator,
         IGuardsService guardsService)
     {
-        _ctx = ctx ?? throw new ArgumentNullException(nameof(ctx));
+        _dbContextOptions = dbContextOptions ?? throw new ArgumentNullException(nameof(dbContextOptions));
         _sourceFormatNodeValidator = sourceFormatNodeValidator ??
                                      throw new ArgumentNullException(nameof(sourceFormatNodeValidator));
         _guards = guardsService ?? throw new ArgumentNullException(nameof(guardsService));

--- a/SourceFormats/SourceFormatsRepository/SourceFormatNode/SourceFormatNodeRepository.cs
+++ b/SourceFormats/SourceFormatsRepository/SourceFormatNode/SourceFormatNodeRepository.cs
@@ -23,11 +23,4 @@ public partial class SourceFormatNodeRepository : ISourceFormatNodeRepository
                                      throw new ArgumentNullException(nameof(sourceFormatNodeValidator));
         _guards = guardsService ?? throw new ArgumentNullException(nameof(guardsService));
     }
-
-    private string prepErrorMessage(string methodName)
-    {
-        string msg = $"Error occured while executing {nameof(SourceFormatNodeRepository)}.{methodName}. " +
-                     "For further information see inner exception!";
-        return msg;
-    }
 }

--- a/SourceFormats/SourceFormatsService.Int.Tests/BaseTest.cs
+++ b/SourceFormats/SourceFormatsService.Int.Tests/BaseTest.cs
@@ -33,6 +33,7 @@ public class BaseTest
         IValidator<SourceFormatNode> nodeValidator = new SourceFormatNodeValidator();
         ISourceFormatNodeMappers sourceFormatNodeMappers = new SourceFormatNodeMappers();
         ISourceFormatMappers mappers = new SourceFormatMappers(sourceFormatNodeMappers);
+
         DbContextOptions<SourceFormatsDbContext> dbContextOptions =
             new DbContextOptionsBuilder<SourceFormatsDbContext>()
                 .UseSqlite(connection).LogTo(m => Debug.WriteLine(m)).EnableSensitiveDataLogging()
@@ -40,8 +41,9 @@ public class BaseTest
                 .Options;
         SourceFormatsDbContext ctx = new(dbContextOptions);
         ctx.Database.EnsureCreated();
+
         ISourceFormatNodeRepository sourceFormatNodeRepository = new SourceFormatNodeRepository(
-            ctx, nodeValidator, new GuardsService());
+            dbContextOptions, nodeValidator, new GuardsService());
         ISourceFormatNodeCacheService sourceFormatNodeCacheService = new SourceFormatNodeCacheService();
         ILogger<SourceFormats.SourceFormatsService.SourceFormatNodeService.SourceFormatNodeService> logger =
             new Logger<SourceFormats.SourceFormatsService.SourceFormatNodeService.SourceFormatNodeService>(

--- a/SourceFormats/SourceFormatsService/SourceFormatNodeService/UpdateAsync.cs
+++ b/SourceFormats/SourceFormatsService/SourceFormatNodeService/UpdateAsync.cs
@@ -8,7 +8,6 @@ using Interfaces;
 using Interfaces.SourceFormatNode;
 using Mappers.Exceptions.SourceFormatNode;
 using Microsoft.Extensions.Logging;
-using SourceFormatsRepository.Exceptions;
 using ValidatorService;
 
 public partial class SourceFormatNodeService
@@ -42,8 +41,7 @@ public partial class SourceFormatNodeService
             };
             return responseModel;
         }
-        catch (Exception e) when (e is SourceFormatNodeRepositoryException &&
-                                  e.InnerException is InvalidOperationException)
+        catch (Exception e) when (e is InvalidOperationException)
         {
             _logger.LogWarning("{Operation} failed due to there is no item in the sequence",
                 nameof(UpdateSourceFormatNodeAsync));


### PR DESCRIPTION
The `SourceFormatRepository` got the context as parameter, meaning it was constructed
outside of the repository which felt a bit odd.
By this change, the repository gets a `DbContextOptions` instance as parameter, so
we still can configure the connection string.
The other change is introducing using `usings` which for some reason I missed.
As a result we can use transactions, and I added almost every operations.

Closes #22 