### PR TITLE
feat: adding pre-build event for the generator test build

### DIFF
--- a/Tools/Generator/Generator.Tests.Unit/Generator.Tests.Unit.csproj
+++ b/Tools/Generator/Generator.Tests.Unit/Generator.Tests.Unit.csproj
@@ -696,4 +696,8 @@
         <Folder Include="Dto\Generation\Reference\SolutionName.Dto\"/>
     </ItemGroup>
 
+    <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+        <Exec Command="./delete_template_directories.sh"/>
+    </Target>
+
 </Project>

--- a/Tools/Generator/Generator.Tests.Unit/delete_template_directories.sh
+++ b/Tools/Generator/Generator.Tests.Unit/delete_template_directories.sh
@@ -1,0 +1,25 @@
+PLATFORM="net7.0"
+
+echo "\n"
+echo "==================================="
+echo "=== Pre-build events executions ==="
+echo "==================================="
+echo "\n"
+
+E2E_DIR="bin/Debug/"$PLATFORM"/e2e"
+echo "Delete " $E2E_DIR
+rm -rf bin/Debug/$PLATFORM/e2e
+
+DTO_DIR="bin/Debug/"$PLATFORM"/Dto"
+echo "Delete " $DTO_DIR
+rm -rf $DTO_DIR
+
+DTO_TESTS_DIR="bin/Debug/"$PLATFORM"/DtoTests"
+echo "Delete " $DTO_TESTS_DIR
+rm -rf bin/Debug/$PLATFORM/DtoTests
+
+echo "\n"
+echo "======================================="
+echo "=== Pre-build events executions end ==="
+echo "======================================="
+echo "\n"


### PR DESCRIPTION
This MR brings the following changes:

- Generator test project got a pre-build event to delete all of the directories where the templates during testing are copied. This way we can prevent lingering templates there causing ezoteric issues