### PR TITLE
fix(generator): Dto Project Namespace value validation for negative cases 

### DIFF
--- a/Doc/antora/modules/devx/pages/generator.adoc
+++ b/Doc/antora/modules/devx/pages/generator.adoc
@@ -122,7 +122,8 @@ It contains all the particular related variable information like:
 
 - the Dto project is placed in the `${target_directory}/${dto_project_name}.Dto` directory
 - the Dto project file is placed in the `${target_directory}/${dto_project_name}.Dto` directory with the name of `${dto_project_name}.Dto.${solution_project_file_type}`, e.g. in case of C# it is `.csproj`
-- the Dto project has namespace value which is generated from the solution base namespace value using the following rule `${solution_base_namespace}.${dto_project_namespace}`, but its default value is `Dto`
+- the Dto project namespace value has to be provided by the configuration file.
+The provided value will be used like folows: `${solution_base_namespace}.${dto_project_namespace}`
 
 ==== Dto Test project level rules
 
@@ -431,6 +432,14 @@ The Dto project name value defines the following in terms of generating code:
 
 - where the generator will look for the Dto project as it will create a path based on the provided name
 
+.Providing "Dto project name" configuration value via json configuration
+[source,json]
+----
+{
+  "dto_project_name": "csproj"
+}
+----
+
 .Input validation rules and result
 |===
 |Input|Validation result
@@ -463,4 +472,40 @@ The Dto project name value defines the following in terms of generating code:
 
 |csharp
 |Dto.Project.Name
+|===
+
+=== Dto Project Namespace
+
+The Dto Project Namespace defines the namespace of the DTO classes in the Dto project.
+
+.Providing "Dto project name" configuration value via json configuration
+[source,json]
+----
+{
+  "dto_project_namespace": "Dto"
+}
+----
+
+.Input validation rules and results
+|===
+|Input|Validation result
+
+|Valid input
+|Code generation
+
+|`null`
+|throws
+
+|`string.empty`
+|throws
+
+|`   ` (whitespace)
+|throws
+
+|Includes other than letters characters
+|throws
+
+|First character is not uppercase
+|First letter is transformed to uppercase
+
 |===

--- a/Doc/antora/modules/devx/pages/generator.adoc
+++ b/Doc/antora/modules/devx/pages/generator.adoc
@@ -436,7 +436,7 @@ The Dto project name value defines the following in terms of generating code:
 [source,json]
 ----
 {
-  "dto_project_name": "csproj"
+  "dto_project_name": "DtoProjectName"
 }
 ----
 
@@ -482,7 +482,7 @@ The Dto Project Namespace defines the namespace of the DTO classes in the Dto pr
 [source,json]
 ----
 {
-  "dto_project_namespace": "Dto"
+  "dto_project_namespace": "DtoNamespace"
 }
 ----
 

--- a/Tools/Generator/Doc/configuration.schema.json
+++ b/Tools/Generator/Doc/configuration.schema.json
@@ -11,7 +11,8 @@
     "target_directory",
     "solution_base_namespace",
     "solution_file_type",
-    "solution_project_file_type"
+    "solution_project_file_type",
+    "dto_project_name"
   ],
   "properties": {
     "lang": {
@@ -40,6 +41,10 @@
     },
     "solution_project_file_type": {
       "description": "REQUIRED: The file type of the solution projects.",
+      "type": "string"
+    },
+    "dto_project_name": {
+      "description": "REQUIRED: The name of the DTO project",
       "type": "string"
     },
     "skip_dto_preprocess": {

--- a/Tools/Generator/Generator.Tests.Unit/Generator.Tests.Unit.csproj
+++ b/Tools/Generator/Generator.Tests.Unit/Generator.Tests.Unit.csproj
@@ -15,11 +15,11 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.12.0"/>
         <PackageReference Include="Microsoft.Build" Version="17.7.2"/>
-        <PackageReference Include="Microsoft.OpenApi" Version="1.6.8" />
-        <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.8" />
+        <PackageReference Include="Microsoft.OpenApi" Version="1.6.8"/>
+        <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.8"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
-        <PackageReference Include="xunit" Version="2.5.1" />
+        <PackageReference Include="xunit" Version="2.5.1"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
@@ -658,6 +658,21 @@
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
         <None Update="e2e\dto_project_name\number_right_after_the_dot.config.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <None Update="e2e\dto_project_namespace\whitespace.config.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <None Update="e2e\dto_project_namespace\not_defined.config.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <None Update="e2e\dto_project_namespace\empty.config.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <None Update="e2e\dto_project_namespace\includes_alphanumeric.config.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+        <None Update="e2e\dto_project_namespace\openapi.yaml">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
     </ItemGroup>

--- a/Tools/Generator/Generator.Tests.Unit/e2e/dto_project_namespace/DtoProjectNameSpaceShould.cs
+++ b/Tools/Generator/Generator.Tests.Unit/e2e/dto_project_namespace/DtoProjectNameSpaceShould.cs
@@ -1,0 +1,42 @@
+namespace EncyclopediaGalactica.RestApiSdkGenerator.Generator.Tests.Unit.e2e.dto_project_namespace;
+
+using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
+using FluentValidation;
+using Generator;
+using Xunit;
+using Xunit.Abstractions;
+
+[ExcludeFromCodeCoverage]
+[Trait("Category", "Generator")]
+[Trait("Category", "Generator-E2E")]
+public class DtoProjectNameSpaceShould : TestBase
+{
+    private readonly string _currentPath;
+
+    public DtoProjectNameSpaceShould(ITestOutputHelper outputHelper) : base(outputHelper)
+    {
+        _currentPath = $"{BasePath}/e2e/dto_project_namespace";
+    }
+
+    [Theory]
+    [InlineData("empty.config.json")]
+    [InlineData("not_defined.config.json")]
+    [InlineData("includes_alphanumeric.config.json")]
+    [InlineData("whitespace.config.json")]
+    public void DtoProjectName_Throws_WhenInputIsInvalid(string fileName)
+    {
+        // Arrange
+        string configFilePath = $"{_currentPath}/{fileName}";
+
+        // Act
+        Action action = () => { new CodeGenerator.Builder().SetPath(configFilePath).Generate(); };
+
+        // Assert
+        action.Should().Throw<GeneratorException>().WithInnerException(typeof(ValidationException));
+    }
+
+    public async Task DtoProjectNamespace_IsTransformedWhenFirstLetterIsNotUppercase()
+    {
+    }
+}

--- a/Tools/Generator/Generator.Tests.Unit/e2e/dto_project_namespace/empty.config.json
+++ b/Tools/Generator/Generator.Tests.Unit/e2e/dto_project_namespace/empty.config.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://github.com/EncyclopediaGalactica/EncyclopediaGalactica/blob/main/Tools/Generator/Doc/configuration.schema.json",
+  "lang": "csharp",
+  "openapi_specification_path": "e2e/dto_project_namespace/openapi.yaml",
+  "target_directory": "e2e/dto_project_namespace",
+  "solution_name": "SolutionName",
+  "solution_base_namespace": "solution.base",
+  "solution_file_type": "sln",
+  "solution_project_file_type": "csproj",
+  "dto_project_name": "DtoProjectName",
+  "dto_project_namespace": "",
+  "dto_project_base_path": "dto_project_base_path",
+  "dto_project_test_unit_name": "dto_test_project_name",
+  "dto_project_test_unit_base_path": "dto_test_project_path",
+  "skip_dto_preprocess": false,
+  "skip_dto_generating": false,
+  "skip_dto_test_preprocessing": true,
+  "skip_dto_test_generating": true
+}

--- a/Tools/Generator/Generator.Tests.Unit/e2e/dto_project_namespace/includes_alphanumeric.config.json
+++ b/Tools/Generator/Generator.Tests.Unit/e2e/dto_project_namespace/includes_alphanumeric.config.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://github.com/EncyclopediaGalactica/EncyclopediaGalactica/blob/main/Tools/Generator/Doc/configuration.schema.json",
+  "lang": "csharp",
+  "openapi_specification_path": "e2e/dto_project_namespace/openapi.yaml",
+  "target_directory": "e2e/dto_project_namespace",
+  "solution_name": "SolutionName",
+  "solution_base_namespace": "solution.base",
+  "solution_file_type": "sln",
+  "solution_project_file_type": "csproj",
+  "dto_project_name": "DtoProjectName",
+  "dto_project_namespace": "alpha123",
+  "dto_project_base_path": "dto_project_base_path",
+  "dto_project_test_unit_name": "dto_test_project_name",
+  "dto_project_test_unit_base_path": "dto_test_project_path",
+  "skip_dto_preprocess": false,
+  "skip_dto_generating": false,
+  "skip_dto_test_preprocessing": true,
+  "skip_dto_test_generating": true
+}

--- a/Tools/Generator/Generator.Tests.Unit/e2e/dto_project_namespace/not_defined.config.json
+++ b/Tools/Generator/Generator.Tests.Unit/e2e/dto_project_namespace/not_defined.config.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://github.com/EncyclopediaGalactica/EncyclopediaGalactica/blob/main/Tools/Generator/Doc/configuration.schema.json",
+  "lang": "csharp",
+  "openapi_specification_path": "e2e/dto_project_namespace/openapi.yaml",
+  "target_directory": "e2e/dto_project_namespace",
+  "solution_name": "SolutionName",
+  "solution_base_namespace": "solution.base",
+  "solution_file_type": "sln",
+  "solution_project_file_type": "csproj",
+  "dto_project_name": "DtoProjectName",
+  "dto_project_base_path": "dto_project_base_path",
+  "dto_project_test_unit_name": "dto_test_project_name",
+  "dto_project_test_unit_base_path": "dto_test_project_path",
+  "skip_dto_preprocess": false,
+  "skip_dto_generating": false,
+  "skip_dto_test_preprocessing": true,
+  "skip_dto_test_generating": true
+}

--- a/Tools/Generator/Generator.Tests.Unit/e2e/dto_project_namespace/openapi.yaml
+++ b/Tools/Generator/Generator.Tests.Unit/e2e/dto_project_namespace/openapi.yaml
@@ -1,0 +1,9 @@
+openapi: 3.0.3
+info:
+  title: Title
+  description: Title
+  version: 1.0.0
+servers:
+  - url: 'https'
+paths:
+  

--- a/Tools/Generator/Generator.Tests.Unit/e2e/dto_project_namespace/whitespace.config.json
+++ b/Tools/Generator/Generator.Tests.Unit/e2e/dto_project_namespace/whitespace.config.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://github.com/EncyclopediaGalactica/EncyclopediaGalactica/blob/main/Tools/Generator/Doc/configuration.schema.json",
+  "lang": "csharp",
+  "openapi_specification_path": "e2e/dto_project_namespace/openapi.yaml",
+  "target_directory": "e2e/dto_project_namespace",
+  "solution_name": "SolutionName",
+  "solution_base_namespace": "solution.base",
+  "solution_file_type": "sln",
+  "solution_project_file_type": "csproj",
+  "dto_project_name": "DtoProjectName",
+  "dto_project_namespace": "   ",
+  "dto_project_base_path": "dto_project_base_path",
+  "dto_project_test_unit_name": "dto_test_project_name",
+  "dto_project_test_unit_base_path": "dto_test_project_path",
+  "skip_dto_preprocess": false,
+  "skip_dto_generating": false,
+  "skip_dto_test_preprocessing": true,
+  "skip_dto_test_generating": true
+}

--- a/Tools/Generator/Generator.Tests.Unit/e2e/target_directory/path_missing.config.json
+++ b/Tools/Generator/Generator.Tests.Unit/e2e/target_directory/path_missing.config.json
@@ -8,7 +8,7 @@
   "solution_file_type": "slnref",
   "solution_project_file_type": "csprojref",
   "dto_project_name": "dto_project_name",
-  "dto_project_namespace": "dto.project",
+  "dto_project_namespace": "dtoproject",
   "dto_project_base_path": "dto_project_base_path",
   "dto_project_test_unit_name": "dto_test_project_name",
   "dto_project_test_unit_base_path": "dto_test_project_path",

--- a/Tools/Generator/Generator.Tests.Unit/e2e/target_directory/target_directory_does_not_exist_absolute.config.json
+++ b/Tools/Generator/Generator.Tests.Unit/e2e/target_directory/target_directory_does_not_exist_absolute.config.json
@@ -9,7 +9,7 @@
   "solution_file_type": "slnref",
   "solution_project_file_type": "csprojref",
   "dto_project_name": "dto_project_name",
-  "dto_project_namespace": "dto.project",
+  "dto_project_namespace": "dtoproject",
   "dto_project_base_path": "dto_project_base_path",
   "dto_project_test_unit_name": "dto_test_project_name",
   "dto_project_test_unit_base_path": "dto_test_project_path",

--- a/Tools/Generator/Generator.Tests.Unit/e2e/target_directory/target_directory_does_not_exist_relative.config.json
+++ b/Tools/Generator/Generator.Tests.Unit/e2e/target_directory/target_directory_does_not_exist_relative.config.json
@@ -9,7 +9,7 @@
   "solution_file_type": "slnref",
   "solution_project_file_type": "csprojref",
   "dto_project_name": "dto_project_name",
-  "dto_project_namespace": "dto.project",
+  "dto_project_namespace": "dtoproject",
   "dto_project_base_path": "dto_project_base_path",
   "dto_project_test_unit_name": "dto_test_project_name",
   "dto_project_test_unit_base_path": "dto_test_project_path",

--- a/Tools/Generator/Generator.Tests.Unit/e2e/target_directory/target_directory_is_empty.config.json
+++ b/Tools/Generator/Generator.Tests.Unit/e2e/target_directory/target_directory_is_empty.config.json
@@ -9,7 +9,7 @@
   "solution_file_type": "slnref",
   "solution_project_file_type": "csprojref",
   "dto_project_name": "dto_project_name",
-  "dto_project_namespace": "dto.project",
+  "dto_project_namespace": "dtoproject",
   "dto_project_base_path": "dto_project_base_path",
   "dto_project_test_unit_name": "dto_test_project_name",
   "dto_project_test_unit_base_path": "dto_test_project_path",

--- a/Tools/Generator/Generator.Tests.Unit/e2e/target_directory/target_directory_is_spaces.config.json
+++ b/Tools/Generator/Generator.Tests.Unit/e2e/target_directory/target_directory_is_spaces.config.json
@@ -9,7 +9,7 @@
   "solution_file_type": "slnref",
   "solution_project_file_type": "csprojref",
   "dto_project_name": "dto_project_name",
-  "dto_project_namespace": "dto.project",
+  "dto_project_namespace": "dtoproject",
   "dto_project_base_path": "dto_project_base_path",
   "dto_project_test_unit_name": "dto_test_project_name",
   "dto_project_test_unit_base_path": "dto_test_project_path",

--- a/Tools/Generator/Generator/Generator/Configuration/CodeGeneratorConfigurationValidator.cs
+++ b/Tools/Generator/Generator/Generator/Configuration/CodeGeneratorConfigurationValidator.cs
@@ -118,6 +118,32 @@ public class CodeGeneratorConfigurationValidator : AbstractValidator<CodeGenerat
                     });
             });
 
+        RuleFor(p => p.DtoProjectNameSpace)
+            .NotNull()
+            .WithMessage("Dto Namespace value must be provided")
+            .DependentRules(() =>
+            {
+                RuleFor(p => p.DtoProjectNameSpace)
+                    .NotEmpty()
+                    .WithMessage("Dto Project Namespace must not be empty")
+                    .DependentRules(() =>
+                    {
+#pragma warning disable CS8602 // Dereference of a possibly null reference.
+                        RuleFor(p => p.DtoProjectNameSpace.Trim().Length)
+#pragma warning restore CS8602 // Dereference of a possibly null reference.
+                            .GreaterThanOrEqualTo(1)
+                            .WithMessage("Dto Project Name must not consists only of space characters.")
+                            .DependentRules(() =>
+                            {
+#pragma warning disable CS8604 // Possible null reference argument.
+                                RuleFor(p => p.DtoProjectNameSpace.All(char.IsLetter))
+#pragma warning restore CS8604 // Possible null reference argument.
+                                    .Equal(true)
+                                    .WithMessage("Dto Project Namespace must contains only letters");
+                            });
+                    });
+            });
+
         RuleFor(p => p.DtoProjectBasePath).NotNull().NotEmpty()
             .WithMessage("Dto project base path must be provided");
 


### PR DESCRIPTION
This MR includes the following changes:
- validation for `DtoProjectNamespace` in the generator
- validation rules cover the negative cases