### PR TITLE
fix: adding dto_project_namespace value to configuration schema

### DIFF
--- a/Tools/Generator/Doc/configuration.schema.json
+++ b/Tools/Generator/Doc/configuration.schema.json
@@ -12,7 +12,8 @@
     "solution_base_namespace",
     "solution_file_type",
     "solution_project_file_type",
-    "dto_project_name"
+    "dto_project_name",
+    "dto_project_namespace"
   ],
   "properties": {
     "lang": {
@@ -45,6 +46,10 @@
     },
     "dto_project_name": {
       "description": "REQUIRED: The name of the DTO project",
+      "type": "string"
+    },
+    "dto_project_namespace": {
+      "description": "REQUIRED: Dto project namespace",
       "type": "string"
     },
     "skip_dto_preprocess": {


### PR DESCRIPTION
This MR brings the following changes:
- `dto_project_namespace` value has been added to the command line configuration file of the generator